### PR TITLE
add sonata admin bundle as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require":{
         "symfony/symfony":">=2.0",
         "sonata-project/easy-extends-bundle":"*",
+        "sonata-project/admin-bundle":"*",
         "friendsofsymfony/user-bundle":"*"
     },
     "suggest":{


### PR DESCRIPTION
composer install didn't work with current composer.json

Was erroring with:

PHP Fatal error:  Class 'Sonata\AdminBundle\Admin\Admin' not found in /Users/danielplatt/Sites/myphone/vendor/liuggio/help-desk-bundle/Liuggio/HelpDeskBundle/Admin/TicketStateAdmin.php on line 11

Update includes sonata admin bundle
