### PR TITLE
use the block name all children refer to

### DIFF
--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -22,7 +22,7 @@
 
 <div id="request" class="container  showForStartup">
     <div class="row-fluid">
-        {% block content %}
+        {% block central %}
         no content to load
         {% endblock %}
     </div>


### PR DESCRIPTION
Default:index expects a block of content, however all descendants assume a block of central
