### PR TITLE
add extra config to enable acls

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ liuggio_help_desk:
 
 5 Add the following entries to security.yml
 
+    security:
+        //...
+        acl:
+            connection: default
+
     access_control:
         //...
         # HelpDesk Ticket system


### PR DESCRIPTION
some config to enable the acls otherwise you get this error:

  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]  
  The service "liuggio_help_desk.acl.manager" has a dependency on a non-existent service "security.acl.provider".  
