### PR TITLE
Pr template content

### DIFF
--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -22,7 +22,7 @@
 
 <div id="request" class="container  showForStartup">
     <div class="row-fluid">
-        {% block central %}
+        {% block content %}
         no content to load
         {% endblock %}
     </div>

--- a/Resources/views/Ticket/index.html.twig
+++ b/Resources/views/Ticket/index.html.twig
@@ -1,5 +1,5 @@
 {% extends 'LiuggioHelpDeskBundle:Default:index.html.twig' %}
-{% block central %}
+{% block content %}
 
 
 <h1>{{ "tickets_entity"|trans }}</h1>
@@ -19,14 +19,14 @@
 <hr/>
 <hr/>
 
-<br/>
 {% if app.session.hasFlash('notice') %}
+<br/>
 <div class="flash-notice">
     {{ app.session.flash('notice') }}
 </div>
 {% endif %}
-<br/>
 {% if entities|length %}
+<br/>
 <table class="records_list">
     <thead>
     <tr>

--- a/Resources/views/Ticket/new.html.twig
+++ b/Resources/views/Ticket/new.html.twig
@@ -1,5 +1,5 @@
 {% extends 'LiuggioHelpDeskBundle:Default:index.html.twig' %}
-{% block central %}
+{% block content %}
 
 <h1>Ticket creation</h1>
 

--- a/Resources/views/Ticket/rate.html.twig
+++ b/Resources/views/Ticket/rate.html.twig
@@ -1,5 +1,5 @@
 {% extends 'LiuggioHelpDeskBundle:Default:index.html.twig' %}
-{% block central %}
+{% block content %}
 
 
 <h1>{{ "rate_action"|trans }}</h1>

--- a/Resources/views/Ticket/show.html.twig
+++ b/Resources/views/Ticket/show.html.twig
@@ -1,5 +1,5 @@
 {% extends 'LiuggioHelpDeskBundle:Default:index.html.twig' %}
-{% block central %}
+{% block content %}
 
 
 <h1>{{ "ticket_entity"|trans }}</h1>


### PR DESCRIPTION
just noticed that operator/ticket use block content, and ticket used central.

This commit revert the previous one, and updates all to use content, as that one is the most used.
